### PR TITLE
bug: invoking GetUserAccessInvitations from personal account

### DIFF
--- a/public/getRepoAccessInvitation.ps1
+++ b/public/getRepoAccessInvitation.ps1
@@ -31,6 +31,14 @@ function Get-RepoAccessInvitations{
 
     $result = Invoke-MyCommandJson -Command GetUserAccessInvitations -Parameters $param
 
+    # Check if we are on a private accoutn and not org account.
+    # This error is returned when the repo is a personal account repo with no invitations possible
+    if($result.message -eq 'Resource not accessible by integration'){
+        "No access invitations for $role to $Owner/$Repo" | Write-Verbose
+        "Very possibly this repo is a personal account repo with no invitations possible" | Write-Verbose
+        return $null
+    }
+
     "Found $($result.count) invitations for role $role" | Write-Verbose
 
     foreach ($item in $result) {


### PR DESCRIPTION
[DBG]:>  Invoke-MyCommand -Command GetUserAccessInvitations -Parameters $param    
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/collaborators/invitations#list-repository-invitations"}
