### PR TITLE
Add --paginate parameter to GetRepoAccess and GetRepoAccessInvitation

### DIFF
--- a/RepoHelperTest/public/getRepoAccess.test.ps1
+++ b/RepoHelperTest/public/getRepoAccess.test.ps1
@@ -4,10 +4,10 @@ function RepoHelperTest_GetRepoAccessAll_SUCCESS{
     $owner = 'solidifycustomers' ; $repo = 'bit21' 
     
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessAllSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators --paginate' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
 
     $GetInvitations = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessInvitationsSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/invitations' -Command "Get-Content -Path $(($GetInvitations | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/invitations --paginate' -Command "Get-Content -Path $(($GetInvitations | Get-Item).FullName)"
 
     $result = Get-RepoAccess -owner $owner -repo $repo
 
@@ -25,7 +25,7 @@ function RepoHelperTest_GetRepoAccess_Success{
     # Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators/raulgeu/permission' -Command "Get-Content -Path $(($GetAccessSuccess | Get-Item).FullName)"
 
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessAllSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators --paginate' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
 
     $result = Get-RepoAccess -Owner $owner -Repo $repo
 

--- a/RepoHelperTest/public/getRepoAccessInvitation.test.ps1
+++ b/RepoHelperTest/public/getRepoAccessInvitation.test.ps1
@@ -3,7 +3,7 @@ function RepoHelperTest_GetRepoInvitations_SUCCESS{
     $owner = 'solidifycustomers' ; $repo = 'bit21' ; $user = 'raulgeu' ; $role = 'write'
 
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessInvitationsSuccess.json'
-    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations" -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations --paginate" -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
 
     $result = Get-RepoAccessInvitations -owner $owner -repo $repo
 
@@ -15,7 +15,7 @@ function RepoHelperTest_GetRepoInvitations_SUCCESS_Ids{
     $owner = 'solidifycustomers' ; $repo = 'bit21' ; $id = 243067060 ; $user = 'raulgeu'
 
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessInvitationsSuccess.json'
-    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations" -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations --paginate" -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
 
     $result = Get-RepoAccessInvitations -owner $owner -repo $repo -Ids
 
@@ -24,9 +24,13 @@ function RepoHelperTest_GetRepoInvitations_SUCCESS_Ids{
 
 function RepoHelperTest_GetRepoInvitations_Empty{
 
-    $owner = 'solidifycustomers' ; $repo = 'bit21' 
+    $owner = 'solidifycustomers' ; $repo = 'bit21'
+    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations --paginate" -Command 'echo "[]"'
 
-    Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations" -Command 'echo "[]"'
+    $command = (Get-InvokeCommandAliasList).GetUserAccessInvitations
+    $command = $command -replace '{owner}', $owner
+    $command = $command -replace '{repo}', $repo
+    Set-InvokeCommandAlias -Alias $command -Command 'echo "[]"'
 
     $result = Get-RepoAccessInvitations -owner $owner -repo $repo
 

--- a/RepoHelperTest/public/grantRepoAccess.test.ps1
+++ b/RepoHelperTest/public/grantRepoAccess.test.ps1
@@ -6,7 +6,7 @@ function RepoHelperTest_GrantRepoAccess_SUCCESS_NotCache{
     # Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/collaborators/$user/permission" -Command "Get-Content -Path $(($GetAccessSuccess | Get-Item).FullName)"
 
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessAllSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators --paginate' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
     
     $grantAccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'grantAccessSuccess.json'
     Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators/raulgeu -X PUT -f permission="write"' -Command "Get-Content -Path $(($grantAccess | Get-Item).FullName)"
@@ -24,7 +24,7 @@ function RepoHelperTest_GrantRepoAccess_SUCCESS_Cached{
     # Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/collaborators/$user/permission" -Command "Get-Content -Path $(($GetAccessSuccess | Get-Item).FullName)"
 
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessAllSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators --paginate' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
 
     $getInvitations = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessInvitationsSuccess.json'
     Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations" -Command "Get-Content -Path $(($getInvitations | Get-Item).FullName)"
@@ -41,7 +41,7 @@ function RepoHelperTest_GrantRepoAccess_fail_wrong_user_repo_owner{
 
     # Checks for user
     $GetAccessAllSuccess = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessAllSuccess.json'
-    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias 'gh api repos/solidifycustomers/bit21/collaborators --paginate' -Command "Get-Content -Path $(($GetAccessAllSuccess | Get-Item).FullName)"
     $getInvitations = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getAccessInvitationsSuccess.json'
     Set-InvokeCommandMock -Alias "gh api repos/$owner/$repo/invitations" -Command "Get-Content -Path $(($getInvitations | Get-Item).FullName)"
 

--- a/public/getRepoAccess.ps1
+++ b/public/getRepoAccess.ps1
@@ -1,5 +1,5 @@
 
-Set-MyInvokeCommandAlias -Alias 'GetUserAccessAll' -Command 'gh api repos/{owner}/{repo}/collaborators'
+Set-MyInvokeCommandAlias -Alias 'GetUserAccessAll' -Command 'gh api repos/{owner}/{repo}/collaborators --paginate'
 Set-MyInvokeCommandAlias -Alias 'TestUserAccess'   -Command 'gh api repos/{owner}/{repo}/collaborators/{user}'
 
 <#

--- a/public/getRepoAccessInvitation.ps1
+++ b/public/getRepoAccessInvitation.ps1
@@ -1,4 +1,4 @@
-Set-MyInvokeCommandAlias -Alias 'GetUserAccessInvitations'   -Command 'gh api repos/{owner}/{repo}/invitations'
+Set-MyInvokeCommandAlias -Alias 'GetUserAccessInvitations'   -Command 'gh api repos/{owner}/{repo}/invitations --paginate'
 Set-MyInvokeCommandAlias -Alias 'CancelRepoAccessInvitation' -Command 'gh api repos/{owner}/{repo}/invitations/{invitation_id} -X DELETE'
 
 <#


### PR DESCRIPTION
This pull request adds the --paginate parameter to the GetRepoAccess and GetRepoAccessInvitation functions in order to retrieve all collaborators and invitations in a paginated manner.