### PR TITLE
bug on get repo property schema

### DIFF
--- a/RepoHelperTest/public/getRepoPropertiesSchema.test.ps1
+++ b/RepoHelperTest/public/getRepoPropertiesSchema.test.ps1
@@ -29,3 +29,22 @@ function RepoHelperTest_GetRepoProperties_NotFound{
 
     Assert-IsNull -Object $result
 }
+
+
+function RepoHelperTest_GetRepoProperties_OneResult{
+
+    $owner = 'solidify-internal'
+
+    $mockFile = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'getRepoPropertiesSchemaOneResult.json'
+    Set-InvokeCommandMock -Alias "gh api orgs/$owner/properties/schema" -Command "Get-Content -Path $(($mockFile | Get-Item).FullName)"
+
+    $result = Get-RepoPropertiesSchema -owner $owner
+
+    Assert-Count -Expected 1 -Presented $result
+    Assert-AreEqual -Presented $result.property_name      -Expected "owner"
+    Assert-AreEqual -Presented $result.value_type         -Expected "string"
+    Assert-AreEqual -Presented $result.required           -Expected "False"
+    Assert-AreEqual -Presented $result.description        -Expected "Person responsable of the well-being of the repo and content"
+    Assert-AreEqual -Presented $result.values_editable_by -Expected "org_actors"
+
+}

--- a/RepoHelperTest/public/testData/getRepoPropertiesSchemaOneResult.json
+++ b/RepoHelperTest/public/testData/getRepoPropertiesSchemaOneResult.json
@@ -1,0 +1,2 @@
+[{"property_name":"owner","value_type":"string","required":false,"description":"Person responsable of the well-being of the repo and content","values_editable_by":"org_actors"}]
+

--- a/public/getRepoPropertiesSchema.ps1
+++ b/public/getRepoPropertiesSchema.ps1
@@ -30,12 +30,14 @@ function Get-RepoPropertiesSchema{
         "Error getting repo information" | Write-Error
         return $null
     }
-    $IsEmpty = [string]::IsNullOrEmpty($result.custom_properties)
-    $ret = $IsEmpty ? $null : $result
 
     # Filter null values.
     # Seen null values in the schema on the beta version
-    $ret = $ret.Where({ $null -ne $_ })
+    $result = $result.Where({ $null -ne $_ })
+
+    # $IsEmpty = $result.Count -eq 0
+    $IsEmpty = [string]::IsNullOrEmpty($result[0].property_name)
+    $ret = $IsEmpty ? $null : $result
 
     "Repo Properties Schema for org [$owner] : " | Write-Verbose
     $ret | Format-List | Out-String | Write-Verbose


### PR DESCRIPTION
When there is a single property on the repo schema then Get-RepoPropertySchema resturns $null list.

Control 
- no properties
- one property
- multible properties