### PR TITLE
Add Get-UserToken function to retrieve GitHub token and update setRepoProperties.ps1 to use it

### DIFF
--- a/Test/public/setRepoPropertiesSuccess.test.ps1
+++ b/Test/public/setRepoPropertiesSuccess.test.ps1
@@ -21,18 +21,21 @@ curl -L -s -H "Authorization: Bearer $env:GH_TOKEN" -X PATCH https://api.github.
 function Test_SetRepoProperties_NotFound{
 
     $owner = 'solidifydemo' ; $repo = 'bit21' ; $property = 'kk' ; $value = 'someValuekk'
+    $token = 'fakeToken'
 
 $cmd = @'
-curl -L -s -H "Authorization: Bearer $env:GH_TOKEN" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
+curl -L -s -H "Authorization: Bearer {token}" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
 '@
     $cmd = $cmd -replace '{owner}',$owner
     $cmd = $cmd -replace '{repo}',$repo
     $cmd = $cmd -replace '{name}',$property
     $cmd = $cmd -replace '{value}',$value
+    $cmd = $cmd -replace '{token}',$token
 
     # If success return null
     $mockfile = $PSScriptRoot | Join-Path -ChildPath 'testData' -AdditionalChildPath 'setRepoPropertiesNotFound.json'
     Set-InvokeCommandMock -Alias $cmd -Command "Get-Content -Path $(($mockfile | Get-Item).FullName)"
+    Set-InvokeCommandMock -Alias getToken -Command "echo $token"
 
     $result = Set-RepoProperty -owner $owner -repo $repo -name $property -value $value @ErrorParameters
 

--- a/Test/public/setRepoPropertiesSuccess.test.ps1
+++ b/Test/public/setRepoPropertiesSuccess.test.ps1
@@ -1,17 +1,20 @@
 function Test_SetRepoProperties_Success{
 
     $owner = 'solidifydemo' ; $repo = 'bit21' ; $property = 'kk' ; $value = 'someValuekk'
+    $token = 'fakeToken'
 
 $cmd = @'
-curl -L -s -H "Authorization: Bearer $env:GH_TOKEN" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
+curl -L -s -H "Authorization: Bearer {token}" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
 '@
     $cmd = $cmd -replace '{owner}',$owner
     $cmd = $cmd -replace '{repo}',$repo
     $cmd = $cmd -replace '{name}',$property
     $cmd = $cmd -replace '{value}',$value
+    $cmd = $cmd -replace '{token}',$token
 
     # If success return null
     Set-InvokeCommandMock -Alias $cmd -Command "echo null"
+    Set-InvokeCommandMock -Alias getToken -Command "echo $token"
 
     $result = Set-RepoProperty -owner $owner -repo $repo -name $property -value $value
 

--- a/public/setRepoProperties.ps1
+++ b/public/setRepoProperties.ps1
@@ -9,6 +9,7 @@ curl -L -s -H "Authorization: Bearer {token}" -X PATCH https://api.github.com/re
 '@
 
 Set-MyInvokeCommandAlias -Alias SetRepoProperty -Command $cmd
+Set-MyInvokeCommandAlias -Alias getToken -Command "Get-UserToken"
 
 <#
 .SYNOPSIS
@@ -34,7 +35,7 @@ function Set-RepoProperty{
 
     "Setting property $Name to $Value for $Owner/$Repo" | Write-Verbose
 
-    $token = Get-UserToken
+    $token = Invoke-MyCommand -Command getToken
 
     $param = @{ owner = $Owner ; repo = $Repo ; name = $Name ; value = $Value ; token= $token}
 
@@ -56,5 +57,5 @@ function Get-UserToken{
         return $null
     }
     return $token
-}
+} Export-ModuleMember -Function Get-UserToken
 

--- a/public/setRepoProperties.ps1
+++ b/public/setRepoProperties.ps1
@@ -50,6 +50,10 @@ function Set-RepoProperty{
     return $null
 } Export-ModuleMember -Function Set-RepoProperty
 
+<#
+.SYNOPSIS
+    Gets the user token from the environment
+#>
 function Get-UserToken{
     $token = $env:GH_TOKEN
     if($null -eq $token){

--- a/public/setRepoProperties.ps1
+++ b/public/setRepoProperties.ps1
@@ -5,7 +5,7 @@
 # This command works
 # curl -L -H "Authorization: Bearer $env:GH_TOKEN" -X PATCH https://api.github.com/repos/solidifydemo/bit21/properties/values -d '{"properties":[{"property_name":"kk","value":"kkvalue23"}]}'
 $cmd = @'
-curl -L -s -H "Authorization: Bearer $env:GH_TOKEN" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
+curl -L -s -H "Authorization: Bearer {token}" -X PATCH https://api.github.com/repos/{owner}/{repo}/properties/values -d '{"properties":[{"property_name":"{name}","value":"{value}"}]}'
 '@
 
 Set-MyInvokeCommandAlias -Alias SetRepoProperty -Command $cmd
@@ -34,7 +34,9 @@ function Set-RepoProperty{
 
     "Setting property $Name to $Value for $Owner/$Repo" | Write-Verbose
 
-    $param = @{ owner = $Owner ; repo = $Repo ; name = $Name ; value = $Value }
+    $token = Get-UserToken
+
+    $param = @{ owner = $Owner ; repo = $Repo ; name = $Name ; value = $Value ; token= $token}
 
     if($PSCmdlet.ShouldProcess("$Owner/$Repo","Set property $Name to $Value")){
         $result = Invoke-MyCommandJson -Command SetRepoProperty -Parameters $param
@@ -46,4 +48,13 @@ function Set-RepoProperty{
     
     return $null
 } Export-ModuleMember -Function Set-RepoProperty
+
+function Get-UserToken{
+    $token = $env:GH_TOKEN
+    if($null -eq $token){
+        "GH_TOKEN environment variable is not set" | Write-Error
+        return $null
+    }
+    return $token
+}
 


### PR DESCRIPTION
This pull request includes updates to the `public/setRepoProperties.ps1` script to enhance security by retrieving the GitHub token dynamically and ensuring it is set before making API requests. The key changes involve modifying the command string to use a token parameter, adding a function to get the user token, and updating the parameter list to include the token.