### PR TITLE
Fix access checks and update token command alias

### DIFF
--- a/Test/public/RepoIssueTimeTracking.test.ps1
+++ b/Test/public/RepoIssueTimeTracking.test.ps1
@@ -143,7 +143,7 @@ function Test_GetRepoIssueTimeTracking_Pipe
 {
     Reset-InvokeCommandMock
 
-    $owner = "rulasgorgkk" ; $repo = "repo1" ; $attributes = "title,comments,url" ; $attributes2 = "number,title,url"
+    $owner = "rulasgorgkk" ; $repo = "repo1" ; $attributes = "title,comments,url" ; $attributes2 = "number,title,state,url"
 
     MockCall -Command "gh issue list -R $owner/$repo --json $attributes2" -filename getIssueList.json
 
@@ -186,7 +186,7 @@ function Test_GetRepoIssueTimeTrackingRecords_Pipe
 {
     Reset-InvokeCommandMock
 
-    $owner = "rulasgorgkk" ; $repo = "repo1" ; $attributes = "title,comments,url" ; $attributes2 = "number,title,url"
+    $owner = "rulasgorgkk" ; $repo = "repo1" ; $attributes = "title,comments,url" ; $attributes2 = "number,title,state,url"
 
     MockCall -Command "gh issue list -R $owner/$repo --json $attributes2" -filename getIssueList.json
 

--- a/Test/public/addRepoIssueComment.test.ps1
+++ b/Test/public/addRepoIssueComment.test.ps1
@@ -53,7 +53,7 @@ function Test_GetRepoIssues_Success{
 
     Reset-InvokeCommandMock
 
-    $owner = 'solidifycustomers' ; $repo = 'bit21' ; $attributes="number,title,url"
+    $owner = 'solidifycustomers' ; $repo = 'bit21' ; $attributes="number,title,state,url"
 
     MockCall -Command "gh issue list -R $owner/$repo --json $attributes" -filename getIssueList.json
 

--- a/public/getRepoAccess.ps1
+++ b/public/getRepoAccess.ps1
@@ -118,8 +118,6 @@ function Test-RepoAccess{
 
     $result = Invoke-MyCommandJson -Command TestUserAccess -Parameters $param 2> $null
 
-    $ret = $null -eq $result
-
     if($null -eq $result){
         "User $User has access to $Owner/$Repo" | Write-Verbose
         $ret = $true

--- a/public/setRepoProperties.ps1
+++ b/public/setRepoProperties.ps1
@@ -9,7 +9,7 @@ curl -L -s -H "Authorization: Bearer {token}" -X PATCH https://api.github.com/re
 '@
 
 Set-MyInvokeCommandAlias -Alias SetRepoProperty -Command $cmd
-Set-MyInvokeCommandAlias -Alias getToken -Command "Get-UserToken"
+Set-MyInvokeCommandAlias -Alias getToken -Command "gh auth token"
 
 <#
 .SYNOPSIS


### PR DESCRIPTION
Remove an unnecessary null check in the `Test-RepoAccess` function, update the `getToken` alias to use the `gh auth token` command, and adjust test mocks to include the state attribute for issues.